### PR TITLE
Add a "match_operator" to the redirect

### DIFF
--- a/Controller/Adminhtml/Redirect/Export.php
+++ b/Controller/Adminhtml/Redirect/Export.php
@@ -41,7 +41,7 @@ class Export extends Index
     {
         $collection = $this->collectionFactory->create();
         $data       = $collection->getData();
-        array_unshift($data, ['id', 'source', 'target', 'status']);
+        array_unshift($data, ['id', 'source', 'target', 'match_operator', 'status']);
         $fileName = 'export.csv';
         $filePath = $this->directoryList->getPath(DirectoryList::VAR_DIR) . DIRECTORY_SEPARATOR . $fileName;
         $this->csvProcessor

--- a/Cron/Write.php
+++ b/Cron/Write.php
@@ -79,7 +79,7 @@ class Write
      */
     protected function parse($redirect) {
         $matchOperator = $this->getMatchOperator($redirect);
-        return 'location' . $matchOperator . ' /' . $redirect['source'] . ' { return ' . $redirect['status'] . ' ' . $redirect['target'] . '; }';
+        return 'location' . $matchOperator . ($matchOperator ? ' ' : '') . '/' . $redirect['source'] . ' { return ' . $redirect['status'] . ' ' . $redirect['target'] . '; }';
     }
 
     protected function getMatchOperator($redirect)

--- a/Cron/Write.php
+++ b/Cron/Write.php
@@ -85,7 +85,7 @@ class Write
     protected function getMatchOperator($redirect)
     {
         $matchOperatorCode = $redirect->getMatchOperator();
-        $matchOperator = $this->matchOperatorSource->getMatchOperatorByCode($matchOperatorCode);
+        $matchOperator = $this->matchOperatorSource->getMatchOperatorByCodeOrDefault($matchOperatorCode);
         return $matchOperator['operator'];
     }
 }

--- a/Cron/Write.php
+++ b/Cron/Write.php
@@ -6,6 +6,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem;
 use Psr\Log\LoggerInterface;
+use WeProvide\NginxRedirect\Exception\Source\Config\MatchOperator\UnknownMatchOperator;
 use WeProvide\NginxRedirect\Model\ResourceModel\Redirect\CollectionFactory as RedirectCollectionFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use WeProvide\NginxRedirect\Model\Source\Config\MatchOperator as MatchOperatorSource;
@@ -85,7 +86,13 @@ class Write
     protected function getMatchOperator($redirect)
     {
         $matchOperatorCode = $redirect->getMatchOperator();
-        $matchOperator = $this->matchOperatorSource->getMatchOperatorByCodeOrDefault($matchOperatorCode);
-        return $matchOperator['operator'];
+
+        try {
+            $matchOperator = $this->matchOperatorSource->getMatchOperatorByCodeOrDefault($matchOperatorCode);
+            return $matchOperator['operator'];
+        } catch (UnknownMatchOperator $exception) {
+            $this->logger->warning($exception->getMessage());
+            return '';
+        }
     }
 }

--- a/Exception/Source/Config/MatchOperator/UnknownMatchOperator.php
+++ b/Exception/Source/Config/MatchOperator/UnknownMatchOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WeProvide\NginxRedirect\Exception\Source\Config\MatchOperator;
+
+use Magento\Framework\Exception\LocalizedException;
+
+class UnknownMatchOperator extends LocalizedException
+{
+
+}

--- a/Model/Source/Config/MatchOperator.php
+++ b/Model/Source/Config/MatchOperator.php
@@ -28,4 +28,9 @@ class MatchOperator implements OptionSourceInterface
             ];
         }, $matchOperatorCodes);
     }
+
+    public function getMatchOperatorByCode(string $matchOperatorCode = null): array
+    {
+        return $this->matchOperators[$matchOperatorCode] ?? $this->defaultMatchOperator;
+    }
 }

--- a/Model/Source/Config/MatchOperator.php
+++ b/Model/Source/Config/MatchOperator.php
@@ -3,6 +3,7 @@
 namespace WeProvide\NginxRedirect\Model\Source\Config;
 
 use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Framework\Exception\LocalizedException;
 
 class MatchOperator implements OptionSourceInterface
 {
@@ -29,8 +30,26 @@ class MatchOperator implements OptionSourceInterface
         }, $matchOperatorCodes);
     }
 
-    public function getMatchOperatorByCode(string $matchOperatorCode = null): array
+    /**
+     * @param string|null $matchOperatorCode
+     * @return array
+     * @throws LocalizedException
+     */
+    public function getMatchOperatorByCodeOrDefault(string $matchOperatorCode = null): array
     {
-        return $this->matchOperators[$matchOperatorCode] ?? $this->defaultMatchOperator;
+        return $this->matchOperators[$matchOperatorCode] ?? $this->getDefaultMatchOperator();
+    }
+
+    /**
+     * @return array
+     * @throws LocalizedException
+     */
+    public function getDefaultMatchOperator(): array
+    {
+        if (!isset($this->matchOperators[$this->defaultMatchOperator])) {
+            throw new LocalizedException(__('Default match operator ("' . $this->defaultMatchOperator . '") does not exist."'));
+        }
+
+        return $this->matchOperators[$this->defaultMatchOperator];
     }
 }

--- a/Model/Source/Config/MatchOperator.php
+++ b/Model/Source/Config/MatchOperator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WeProvide\NginxRedirect\Model\Source\Config;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class MatchOperator implements OptionSourceInterface
+{
+    private $defaultMatchOperator;
+    private $matchOperators;
+
+    public function __construct(string $defaultMatchOperator, array $matchOperators)
+    {
+        $this->defaultMatchOperator = $matchOperators[$defaultMatchOperator];
+        $this->matchOperators       = $matchOperators;
+    }
+
+    public function toOptionArray()
+    {
+        $matchOperatorCodes = array_keys($this->matchOperators);
+
+        return array_map(function($matchOperatorCode) {
+            $matchOperator = $this->matchOperators[$matchOperatorCode];
+
+            return [
+                'label' => $matchOperator['label'],
+                'value' => $matchOperatorCode
+            ];
+        }, $matchOperatorCodes);
+    }
+}

--- a/Model/Source/Config/MatchOperator.php
+++ b/Model/Source/Config/MatchOperator.php
@@ -4,6 +4,7 @@ namespace WeProvide\NginxRedirect\Model\Source\Config;
 
 use Magento\Framework\Data\OptionSourceInterface;
 use Magento\Framework\Exception\LocalizedException;
+use WeProvide\NginxRedirect\Exception\Source\Config\MatchOperator\UnknownMatchOperator;
 
 class MatchOperator implements OptionSourceInterface
 {
@@ -33,7 +34,7 @@ class MatchOperator implements OptionSourceInterface
     /**
      * @param string|null $matchOperatorCode
      * @return array
-     * @throws LocalizedException
+     * @throws UnknownMatchOperator
      */
     public function getMatchOperatorByCodeOrDefault(string $matchOperatorCode = null): array
     {
@@ -42,12 +43,12 @@ class MatchOperator implements OptionSourceInterface
 
     /**
      * @return array
-     * @throws LocalizedException
+     * @throws UnknownMatchOperator
      */
     public function getDefaultMatchOperator(): array
     {
         if (!isset($this->matchOperators[$this->defaultMatchOperator])) {
-            throw new LocalizedException(__('Default match operator ("' . $this->defaultMatchOperator . '") does not exist."'));
+            throw new UnknownMatchOperator(__('Default match operator ("' . $this->defaultMatchOperator . '") does not exist."'));
         }
 
         return $this->matchOperators[$this->defaultMatchOperator];

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WeProvide\NginxRedirect\Setup;
 
 use Magento\Framework\DB\Ddl\Table;
@@ -6,31 +7,67 @@ use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
 
-class UpgradeSchema implements UpgradeSchemaInterface {
-    public function upgrade(
-        SchemaSetupInterface $setup,
-        ModuleContextInterface $context
-    ) {
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    const NGINX_REDIRECTS_TABLE = 'nginxredirects';
+
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
         $setup->startSetup();
 
-        if(version_compare($context->getVersion(), '1.1.0') < 0) {
-            $setup->getConnection()->addColumn($setup->getConnection()->getTableName('nginxredirects'), 'created_at', [
-                'type' => Table::TYPE_TIMESTAMP,
-                'default' => Table::TIMESTAMP_INIT,
-                'nullable' => false,
-                'after' => 'status',
-                'comment' => 'Created At'
-            ]);
+        if ($this->shouldRunUpgrade('1.1.0', $context)) {
+            $this->addCreatedAtColumn($setup);
+            $this->addUpdatedAtColumn($setup);
+        }
 
-            $setup->getConnection()->addColumn($setup->getConnection()->getTableName('nginxredirects'), 'updated_at', [
-                'type' => Table::TYPE_TIMESTAMP,
-                'default' => Table::TIMESTAMP_INIT_UPDATE,
-                'nullable' => false,
-                'after' => 'created_at',
-                'comment' => 'Updated At'
-            ]);
+        if ($this->shouldRunUpgrade('1.2.0', $context)) {
+            $this->addMatchOperatorColumn($setup);
         }
 
         $setup->endSetup();
+    }
+
+    protected function shouldRunUpgrade(string $majorMinorPatch, ModuleContextInterface $context): bool
+    {
+        return version_compare($context->getVersion(), $majorMinorPatch) < 0;
+    }
+
+    protected function addCreatedAtColumn(SchemaSetupInterface $setup)
+    {
+        $this->addColumn('created_at', [
+            'type' => Table::TYPE_TIMESTAMP,
+            'default' => Table::TIMESTAMP_INIT,
+            'nullable' => false,
+            'after' => 'status',
+            'comment' => 'Created At'
+        ], $setup);
+    }
+
+    protected function addUpdatedAtColumn(SchemaSetupInterface $setup)
+    {
+        $this->addColumn('updated_at', [
+            'type' => Table::TYPE_TIMESTAMP,
+            'default' => Table::TIMESTAMP_INIT_UPDATE,
+            'nullable' => false,
+            'after' => 'created_at',
+            'comment' => 'Updated At'
+        ], $setup);
+    }
+
+    protected function addMatchOperatorColumn(SchemaSetupInterface $setup)
+    {
+        $this->addColumn('match_operator', [
+            'type' => Table::TYPE_TEXT,
+            'default' => null,
+            'nullable' => true,
+            'after' => 'target',
+            'comment' => 'What match operator to use in the Nginx configuration.'
+        ], $setup);
+    }
+
+    protected function addColumn(string $columnName, array $definition, SchemaSetupInterface $setup)
+    {
+        $validTableName = $setup->getConnection()->getTableName(self::NGINX_REDIRECTS_TABLE);
+        $setup->getConnection()->addColumn($validTableName, $columnName, $definition);
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -60,6 +60,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
             'type' => Table::TYPE_TEXT,
             'default' => null,
             'nullable' => true,
+            'length' => 255,
             'after' => 'target',
             'comment' => 'What match operator to use in the Nginx configuration.'
         ], $setup);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,4 +13,37 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="WeProvide\NginxRedirect\Model\Source\Config\MatchOperator">
+        <arguments>
+            <argument name="defaultMatchOperator" xsi:type="string">prefix</argument>
+
+            <argument name="matchOperators" xsi:type="array">
+                <item name="prefix" xsi:type="array">
+                    <item name="label" xsi:type="string">Default (Prefix)</item>
+                    <item name="operator" xsi:type="string" />
+                </item>
+
+                <item name="exact" xsi:type="array">
+                    <item name="label" xsi:type="string">Exact (=)</item>
+                    <item name="operator" xsi:type="string">=</item>
+                </item>
+
+                <item name="case-sensitive-regular-expression" xsi:type="array">
+                    <item name="label" xsi:type="string">Case-Sensitive Regular Expression (~)</item>
+                    <item name="operator" xsi:type="string">~</item>
+                </item>
+
+                <item name="case-insensitive-regular-expression" xsi:type="array">
+                    <item name="label" xsi:type="string">Case-Insensitive Regular Expression (~*)</item>
+                    <item name="operator" xsi:type="string">~*</item>
+                </item>
+
+                <item name="best-non-regular-expression-match" xsi:type="array">
+                    <item name="label" xsi:type="string">Best Non-Regular Expression Match (^~)</item>
+                    <item name="operator" xsi:type="string">^~</item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="WeProvide_NginxRedirect" setup_version="1.1.0"/>
+	<module name="WeProvide_NginxRedirect" setup_version="1.2.0"/>
 </config>

--- a/view/adminhtml/ui_component/redirect_form.xml
+++ b/view/adminhtml/ui_component/redirect_form.xml
@@ -87,6 +87,17 @@
                 </item>
             </argument>
         </field>
+        <field name="match_operator">
+            <argument name="data" xsi:type="array">
+                <item name="options" xsi:type="object">WeProvide\NginxRedirect\Model\Source\Config\MatchOperator</item>
+                <item name="config" xsi:type="array">
+                    <item name="dataType" xsi:type="string">text</item>
+                    <item name="label" xsi:type="string" translate="true">Matching</item>
+                    <item name="formElement" xsi:type="string">select</item>
+                    <item name="dataScope" xsi:type="string">match_operator</item>
+                </item>
+            </argument>
+        </field>
         <field name="status">
             <argument name="data" xsi:type="array">
                 <item name="options" xsi:type="object">WeProvide\NginxRedirect\Model\Status</item>

--- a/view/adminhtml/ui_component/redirect_listing.xml
+++ b/view/adminhtml/ui_component/redirect_listing.xml
@@ -154,6 +154,17 @@
                 </item>
             </argument>
         </column>
+        <column name="match_operator">
+            <argument name="data" xsi:type="array">
+                <item name="options" xsi:type="object">WeProvide\NginxRedirect\Model\Source\Config\MatchOperator</item>
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">select</item>
+                    <item name="dataType" xsi:type="string">multiselect</item>
+                    <item name="sorting" xsi:type="string">asc</item>
+                    <item name="label" translate="true" xsi:type="string">Matching</item>
+                </item>
+            </argument>
+        </column>
         <column name="status">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">


### PR DESCRIPTION
In nginx you can specify a modifier for the location directive to specify how to match the the request path to the path on the right.

At the moment we use the default, "prefix", by not specifying a modifier and only the location directive and the path. We do currently not support a way to specify the modifier in our redirect model, and as such you have to use the default modifier and no other.

In this pull request I add the "match_operator" to the redirect model to specify the modifier to use in the generated nginx configuration file. 

https://www.journaldev.com/26342/nginx-location-directive#nginx-location-directive-syntax